### PR TITLE
docs: standardize readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 > An (unofficial) [Flagsmith](https://www.flagsmith.com) Vue.js integration that uses [Vue Composition API](https://vuejs.org/guide/extras/composition-api-faq.html) to dynamically update feature flags and traits in components. Compatible with Vue.js versions `2.7` and `3`.
 
-[![npm](https://img.shields.io/npm/v/flagsmith-vue?color=red)](https://www.npmjs.com/package/flagsmith-vue) [![GitHub](https://img.shields.io/github/package-json/v/jhoermann/flagsmith-vue?color=blue&logo=github)](https://github.com/jhoermann/flagsmith-vue) ![GitHub tests workflow](https://github.com/jhoermann/flagsmith-vue/actions/workflows/tests.yml/badge.svg) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/27a356f30e97429e9c8c0b865e41240a)](https://app.codacy.com/gh/jhoermann/flagsmith-vue/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade) [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/27a356f30e97429e9c8c0b865e41240a)](https://app.codacy.com/gh/jhoermann/flagsmith-vue/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
+[![npm][badge-npm]][npm] [![GitHub][badge-github]][github] [![GitHub tests workflow][badge-actions]][actions] [![Codacy Code Quality][badge-codacy]][codacy] [![Codacy Coverage][badge-coverage]][codacy]
+
+[npm]: https://www.npmjs.com/package/flagsmith-vue
+[github]: https://github.com/jhoermann/flagsmith-vue
+[actions]: https://github.com/jhoermann/flagsmith-vue/actions/workflows/tests.yml?query=branch%3Amain
+[codacy]: https://app.codacy.com/gh/jhoermann/flagsmith-vue/dashboard
+
+[badge-npm]: https://img.shields.io/npm/v/flagsmith-vue?logo=npm&logoColor=white&color=red
+[badge-github]: https://img.shields.io/github/package-json/v/jhoermann/flagsmith-vue?logo=github&color=blue
+[badge-actions]: https://img.shields.io/github/actions/workflow/status/jhoermann/flagsmith-vue/tests.yml?logo=github&label=Tests
+[badge-codacy]: https://img.shields.io/codacy/grade/27a356f30e97429e9c8c0b865e41240a?logo=codacy
+[badge-coverage]: https://img.shields.io/codacy/coverage/27a356f30e97429e9c8c0b865e41240a?logo=codacy
 
 ## Installation
 


### PR DESCRIPTION
1. Link GitHub Actions badge to https://github.com/jhoermann/flagsmith-vue/actions/workflows/tests.yml?query=branch%3Amain, so all badges are linked somewhere relevant
2. Remove `utm` parameters from Codacy links
3. Use [Shields.io](https://shields.io/) for all badges, so their style is consistent
4. Add icon to npm badge, so all badges have links
5. Use [reference-style Markdown links](https://www.markdownguide.org/basic-syntax/#reference-style-links) for badge links and images, to make the Markdown more readable