### PR TITLE
feat: allow setting traits after setup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import type {
     ITraits,
     LoadingState,
     FlagSource,
+    IFlagsmith,
 } from 'flagsmith/types'
 import { computed, inject, provide, ref } from 'vue'
 import type { ComputedRef, InjectionKey, Ref } from 'vue'
@@ -15,6 +16,8 @@ export interface FlagsmithHelper<F extends string = string, T extends string = s
     flags: Ref<IFlags<F> | undefined>
     traits: Ref<ITraits<T> | undefined>
     loadingState: Ref<LoadingState | undefined>
+    setTrait: IFlagsmith<F, T>['setTrait']
+    setTraits: IFlagsmith<F, T>['setTraits']
 }
 const FlagsmithInjectionKey: InjectionKey<FlagsmithHelper> = Symbol('FlagsmithInjectionKey')
 const injectHelper = (flagsmithHelper?: FlagsmithHelper): FlagsmithHelper => {
@@ -48,6 +51,8 @@ export const useFlagsmith = <F extends string = string, T extends string = strin
         flags,
         traits,
         loadingState,
+        setTrait: flagsmithInstance.setTrait,
+        setTraits: flagsmithInstance.setTraits,
     }
     provide(FlagsmithInjectionKey, helper)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,9 @@ export interface FlagsmithHelper<F extends string = string, T extends string = s
     setTraits: IFlagsmith<F, T>['setTraits']
 }
 const FlagsmithInjectionKey: InjectionKey<FlagsmithHelper> = Symbol('FlagsmithInjectionKey')
-const injectHelper = (flagsmithHelper?: FlagsmithHelper): FlagsmithHelper => {
+const injectHelper = <F extends string = string, T extends string = string>(
+    flagsmithHelper?: FlagsmithHelper<F, T>
+): FlagsmithHelper<F, T> => {
     const helper = flagsmithHelper ?? inject(FlagsmithInjectionKey)
 
     if (helper === undefined) {
@@ -63,9 +65,9 @@ type ComputedObject<Key extends string, ComputedValue> = {
     [K in Key]: ComputedRef<ComputedValue>
 }
 
-export const useFlags = <F extends string = string>(
+export const useFlags = <F extends string = string, T extends string = string>(
     flagsToUse: F[],
-    flagsmithHelper?: FlagsmithHelper
+    flagsmithHelper?: FlagsmithHelper<F, T>
 ): ComputedObject<F, IFlagsmithFeature | undefined> => {
     const { flags } = injectHelper(flagsmithHelper)
     return Object.fromEntries(
@@ -73,9 +75,9 @@ export const useFlags = <F extends string = string>(
     ) as ComputedObject<F, IFlagsmithFeature | undefined>
 }
 
-export const useTraits = <T extends string = string>(
+export const useTraits = <F extends string = string, T extends string = string>(
     traitsToUse: T[],
-    flagsmithHelper?: FlagsmithHelper
+    flagsmithHelper?: FlagsmithHelper<F, T>
 ): ComputedObject<T, IFlagsmithTrait | undefined> => {
     const { traits } = injectHelper(flagsmithHelper)
     return Object.fromEntries(
@@ -83,8 +85,8 @@ export const useTraits = <T extends string = string>(
     ) as ComputedObject<T, IFlagsmithTrait | undefined>
 }
 
-export const useFlagsmithLoading = (
-    flagsmithHelper?: FlagsmithHelper
+export const useFlagsmithLoading = <F extends string = string, T extends string = string>(
+    flagsmithHelper?: FlagsmithHelper<F, T>
 ): {
     [K in keyof LoadingState]: ComputedRef<LoadingState[K]>
 } => {


### PR DESCRIPTION
This PR forwards the [`setTrait` and `setTraits` functions](https://docs.flagsmith.com/clients/javascript#available-functions) from Flagsmith to the Flagsmith helper. Otherwise, there is no way of setting traits after the setup function is called (which must happen synchronously in a component, so we can't wait for requests to finish before setup).

Also includes a potentially-breaking bug fix: The types for `useFlags`, `useTraits` and `useFlagsmithLoading` previously referenced `FlagsmithHelper` (i.e. `FlagsmithHelper<string, string>` because those are the defaults) instead of `FlagsmithHelper<F, T>`, so it was impossible to pass a `FlagsmithHelper<F, T>` to it. By making the functions fully generic, this problem is avoided.

Unfortunately, this is a (slightly) breaking change, because for consistency, the first type parameter for `useTraits` changed from `T` to `F`.