### PR TITLE
feat: allow accessing Flagsmith instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ useFlagsmith(options)
 
 For `options` see [Flagsmith initialization options](https://docs.flagsmith.com/clients/javascript#initialisation-options).
 
-Then you can access the flags, traits and loading status inside your child components:
+Then you can access the flags, traits, loading status and the Flagsmith instance itself inside your child components:
 
 ```ts
 import { useFlags, useTraits, useFlagsmithLoading } from 'flagsmith-vue'
@@ -41,6 +41,7 @@ import { useFlags, useTraits, useFlagsmithLoading } from 'flagsmith-vue'
 const flags = useFlags(['flag1', 'flag2', ...])
 const traits = useTraits(['trait1', 'trait2', ...])
 const flagsmithLoading = useFlagsmithLoading()
+const { setTraits } = useFlagsmithInstance()
 ```
 
 ## License

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import type {
     ITraits,
     LoadingState,
     FlagSource,
+    IFlagsmith,
 } from 'flagsmith/types'
 import { computed, inject, provide, ref } from 'vue'
 import type { ComputedRef, InjectionKey, Ref } from 'vue'
@@ -15,6 +16,7 @@ export interface FlagsmithHelper<F extends string = string, T extends string = s
     flags: Ref<IFlags<F> | undefined>
     traits: Ref<ITraits<T> | undefined>
     loadingState: Ref<LoadingState | undefined>
+    flagsmithInstance: IFlagsmith<F, T>
 }
 const FlagsmithInjectionKey: InjectionKey<FlagsmithHelper> = Symbol('FlagsmithInjectionKey')
 const injectHelper = <F extends string = string, T extends string = string>(
@@ -50,6 +52,7 @@ export const useFlagsmith = <F extends string = string, T extends string = strin
         flags,
         traits,
         loadingState,
+        flagsmithInstance,
     }
     provide(FlagsmithInjectionKey, helper)
 
@@ -92,4 +95,11 @@ export const useFlagsmithLoading = <F extends string = string, T extends string 
         isLoading: computed(() => Boolean(loadingState.value?.isLoading)),
         source: computed(() => loadingState.value?.source ?? ('NONE' as FlagSource)),
     }
+}
+
+export const useFlagsmithInstance = <F extends string = string, T extends string = string>(
+    flagsmithHelper?: FlagsmithHelper<F, T>
+): IFlagsmith<F, T> => {
+    const { flagsmithInstance } = injectHelper(flagsmithHelper)
+    return flagsmithInstance
 }


### PR DESCRIPTION
via new `flagsmithInstance` property and `useFlagsmithInstance` function.

This replaces #74, which only allowed access to certain methods of the instance.